### PR TITLE
Adding Signal SMS verification strings.

### DIFF
--- a/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
@@ -130,7 +130,7 @@ public class AccountController {
     if (testDevices.containsKey(number)) {
       // noop
     } else if (transport.equals("sms")) {
-      smsSender.deliverSmsVerification(number, client, verificationCode.getVerificationCodeDisplay());
+      smsSender.deliverSmsVerification(number, client, verificationCode);
     } else if (transport.equals("voice")) {
       smsSender.deliverVoxVerification(number, verificationCode.getVerificationCodeSpeech());
     }

--- a/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
@@ -51,6 +51,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -103,7 +104,8 @@ public class AccountController {
   @GET
   @Path("/{transport}/code/{number}")
   public Response createAccount(@PathParam("transport") String transport,
-                                @PathParam("number")    String number)
+                                @PathParam("number")    String number,
+                                @QueryParam("client")   String client)
       throws IOException, RateLimitExceededException
   {
     if (!Util.isValidNumber(number)) {
@@ -128,7 +130,7 @@ public class AccountController {
     if (testDevices.containsKey(number)) {
       // noop
     } else if (transport.equals("sms")) {
-      smsSender.deliverSmsVerification(number, verificationCode.getVerificationCodeDisplay());
+      smsSender.deliverSmsVerification(number, client, verificationCode.getVerificationCodeDisplay());
     } else if (transport.equals("voice")) {
       smsSender.deliverVoxVerification(number, verificationCode.getVerificationCodeSpeech());
     }

--- a/src/main/java/org/whispersystems/textsecuregcm/sms/NexmoSmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/NexmoSmsSender.java
@@ -19,6 +19,7 @@ package org.whispersystems.textsecuregcm.sms;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.configuration.NexmoConfiguration;
@@ -56,10 +57,18 @@ public class NexmoSmsSender {
     this.number    = config.getNumber();
   }
 
-  public void deliverSmsVerification(String destination, String verificationCode) throws IOException {
-    URL url = new URL(String.format(NEXMO_SMS_URL, apiKey, apiSecret, number, destination,
-                                    URLEncoder.encode(SmsSender.SMS_VERIFICATION_TEXT + verificationCode, "UTF-8")));
+  public void deliverSmsVerification(String destination, String clientType, String verificationCode) throws IOException {
+    String verificationMsg;
 
+    if ("ios".equals(clientType)) {
+      verificationMsg = String.format(SmsSender.SMS_IOS_VERIFICATION_TEXT, verificationCode, verificationCode);
+    } else {
+      verificationMsg = String.format(SmsSender.SMS_VERIFICATION_TEXT, verificationCode);
+    }
+
+    URL url = new URL(String.format(NEXMO_SMS_URL, apiKey, apiSecret, number, destination,
+                                    URLEncoder.encode(verificationMsg, "UTF-8")));
+	
     URLConnection connection = url.openConnection();
     connection.setDoInput(true);
     connection.connect();

--- a/src/main/java/org/whispersystems/textsecuregcm/sms/NexmoSmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/NexmoSmsSender.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.configuration.NexmoConfiguration;
 import org.whispersystems.textsecuregcm.util.Constants;
+import org.whispersystems.textsecuregcm.util.VerificationCode;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -57,13 +58,13 @@ public class NexmoSmsSender {
     this.number    = config.getNumber();
   }
 
-  public void deliverSmsVerification(String destination, String clientType, String verificationCode) throws IOException {
+  public void deliverSmsVerification(String destination, String clientType, VerificationCode verificationCode) throws IOException {
     String verificationMsg;
 
     if ("ios".equals(clientType)) {
-      verificationMsg = String.format(SmsSender.SMS_IOS_VERIFICATION_TEXT, verificationCode, verificationCode);
+      verificationMsg = String.format(SmsSender.SMS_IOS_VERIFICATION_TEXT, verificationCode.getVerificationCode(), verificationCode.getVerificationCode());
     } else {
-      verificationMsg = String.format(SmsSender.SMS_VERIFICATION_TEXT, verificationCode);
+      verificationMsg = String.format(SmsSender.SMS_VERIFICATION_TEXT, verificationCode.getVerificationCodeDisplay());
     }
 
     URL url = new URL(String.format(NEXMO_SMS_URL, apiKey, apiSecret, number, destination,

--- a/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
@@ -21,6 +21,7 @@ import com.google.common.base.Optional;
 import com.twilio.sdk.TwilioRestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.whispersystems.textsecuregcm.util.VerificationCode;
 
 import java.io.IOException;
 
@@ -44,7 +45,7 @@ public class SmsSender {
     this.nexmoSender           = nexmoSender;
   }
 
-  public void deliverSmsVerification(String destination, String clientType, String verificationCode)
+  public void deliverSmsVerification(String destination, String clientType, VerificationCode verificationCode)
       throws IOException
   {
     if (!isTwilioDestination(destination) && nexmoSender.isPresent()) {

--- a/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 public class SmsSender {
-
+  static final String SMS_IOS_VERIFICATION_TEXT = "Your Signal verification code: %s\n\nOr tap: sgnl://verify/%s";
   static final String SMS_VERIFICATION_TEXT = "Your TextSecure verification code: ";
-  static final String VOX_VERIFICATION_TEXT = "Your TextSecure verification code is: ";
+  static final String VOX_VERIFICATION_TEXT = "Your Signal verification code is: ";
 
   private final Logger logger = LoggerFactory.getLogger(SmsSender.class);
 
@@ -44,18 +44,18 @@ public class SmsSender {
     this.nexmoSender           = nexmoSender;
   }
 
-  public void deliverSmsVerification(String destination, String verificationCode)
+  public void deliverSmsVerification(String destination, String clientType, String verificationCode)
       throws IOException
   {
     if (!isTwilioDestination(destination) && nexmoSender.isPresent()) {
-      nexmoSender.get().deliverSmsVerification(destination, verificationCode);
+      nexmoSender.get().deliverSmsVerification(destination, clientType, verificationCode);
     } else {
       try {
-        twilioSender.deliverSmsVerification(destination, verificationCode);
+        twilioSender.deliverSmsVerification(destination, clientType, verificationCode);
       } catch (TwilioRestException e) {
         logger.info("Twilio SMS Failed: " + e.getErrorMessage());
         if (nexmoSender.isPresent()) {
-          nexmoSender.get().deliverSmsVerification(destination, verificationCode);
+          nexmoSender.get().deliverSmsVerification(destination, clientType, verificationCode);
         }
       }
     }

--- a/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
@@ -27,6 +27,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.whispersystems.textsecuregcm.configuration.TwilioConfiguration;
 import org.whispersystems.textsecuregcm.util.Constants;
+import org.whispersystems.textsecuregcm.util.VerificationCode;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public class TwilioSmsSender {
     this.localDomain  = config.getLocalDomain();
   }
 
-  public void deliverSmsVerification(String destination, String clientType, String verificationCode)
+  public void deliverSmsVerification(String destination, String clientType, VerificationCode verificationCode)
       throws IOException, TwilioRestException
   {
     TwilioRestClient    client         = new TwilioRestClient(accountId, accountToken);
@@ -69,9 +70,9 @@ public class TwilioSmsSender {
     messageParams.add(new BasicNameValuePair("From", number));
     
     if ("ios".equals(clientType)) {
-      messageParams.add(new BasicNameValuePair("Body", String.format(SmsSender.SMS_IOS_VERIFICATION_TEXT, verificationCode, verificationCode)));
+      messageParams.add(new BasicNameValuePair("Body", String.format(SmsSender.SMS_IOS_VERIFICATION_TEXT, verificationCode.getVerificationCode(), verificationCode.getVerificationCode())));
     } else {
-      messageParams.add(new BasicNameValuePair("Body", String.format(SmsSender.SMS_VERIFICATION_TEXT, verificationCode)));
+      messageParams.add(new BasicNameValuePair("Body", String.format(SmsSender.SMS_VERIFICATION_TEXT, verificationCode.getVerificationCodeDisplay())));
     }
 	
     try {

--- a/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/TwilioSmsSender.java
@@ -59,7 +59,7 @@ public class TwilioSmsSender {
     this.localDomain  = config.getLocalDomain();
   }
 
-  public void deliverSmsVerification(String destination, String verificationCode)
+  public void deliverSmsVerification(String destination, String clientType, String verificationCode)
       throws IOException, TwilioRestException
   {
     TwilioRestClient    client         = new TwilioRestClient(accountId, accountToken);
@@ -67,8 +67,13 @@ public class TwilioSmsSender {
     List<NameValuePair> messageParams  = new LinkedList<>();
     messageParams.add(new BasicNameValuePair("To", destination));
     messageParams.add(new BasicNameValuePair("From", number));
-    messageParams.add(new BasicNameValuePair("Body", SmsSender.SMS_VERIFICATION_TEXT + verificationCode));
-
+    
+    if ("ios".equals(clientType)) {
+      messageParams.add(new BasicNameValuePair("Body", String.format(SmsSender.SMS_IOS_VERIFICATION_TEXT, verificationCode, verificationCode)));
+    } else {
+      messageParams.add(new BasicNameValuePair("Body", String.format(SmsSender.SMS_VERIFICATION_TEXT, verificationCode)));
+    }
+	
     try {
       messageFactory.create(messageParams);
     } catch (RuntimeException damnYouTwilio) {

--- a/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/AccountControllerTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/AccountControllerTest.java
@@ -20,6 +20,7 @@ import org.whispersystems.textsecuregcm.storage.MessagesManager;
 import org.whispersystems.textsecuregcm.storage.PendingAccountsManager;
 import org.whispersystems.textsecuregcm.tests.util.AuthHelper;
 import org.whispersystems.textsecuregcm.util.SystemMapper;
+import org.whispersystems.textsecuregcm.util.VerificationCode;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -82,7 +83,7 @@ public class AccountControllerTest {
 
     assertThat(response.getStatus()).isEqualTo(200);
 
-    verify(smsSender).deliverSmsVerification(eq(SENDER), isNull(String.class), anyString());
+    verify(smsSender).deliverSmsVerification(eq(SENDER), isNull(String.class), any(VerificationCode.class));
   }
   
   @Test
@@ -96,7 +97,7 @@ public class AccountControllerTest {
 
     assertThat(response.getStatus()).isEqualTo(200);
 
-    verify(smsSender).deliverSmsVerification(eq(SENDER), eq("ios"), anyString());
+    verify(smsSender).deliverSmsVerification(eq(SENDER), eq("ios"), any(VerificationCode.class));
   }
 
   @Test

--- a/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/AccountControllerTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/AccountControllerTest.java
@@ -82,7 +82,21 @@ public class AccountControllerTest {
 
     assertThat(response.getStatus()).isEqualTo(200);
 
-    verify(smsSender).deliverSmsVerification(eq(SENDER), anyString());
+    verify(smsSender).deliverSmsVerification(eq(SENDER), isNull(String.class), anyString());
+  }
+  
+  @Test
+  public void testSendiOSCode() throws Exception {
+    Response response =
+        resources.getJerseyTest()
+                 .target(String.format("/v1/accounts/sms/code/%s", SENDER))
+                 .queryParam("client", "ios")
+                 .request()
+                 .get();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+
+    verify(smsSender).deliverSmsVerification(eq(SENDER), eq("ios"), anyString());
   }
 
   @Test

--- a/src/test/java/org/whispersystems/textsecuregcm/tests/sms/DeliveryPreferenceTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/sms/DeliveryPreferenceTest.java
@@ -6,6 +6,7 @@ import junit.framework.TestCase;
 import org.whispersystems.textsecuregcm.sms.NexmoSmsSender;
 import org.whispersystems.textsecuregcm.sms.SmsSender;
 import org.whispersystems.textsecuregcm.sms.TwilioSmsSender;
+import org.whispersystems.textsecuregcm.util.VerificationCode;
 
 import java.io.IOException;
 
@@ -21,16 +22,16 @@ public class DeliveryPreferenceTest extends TestCase {
   public void testInternationalPreferenceOff() throws IOException, TwilioRestException {
     SmsSender smsSender = new SmsSender(twilioSender, Optional.of(nexmoSender), false);
 
-    smsSender.deliverSmsVerification("+441112223333", null, "123-456");
-    verify(nexmoSender).deliverSmsVerification("+441112223333", null, "123-456");
+    smsSender.deliverSmsVerification("+441112223333", null, new VerificationCode(123456));
+    verify(nexmoSender).deliverSmsVerification("+441112223333", null, new VerificationCode(123456));
     verifyNoMoreInteractions(twilioSender);
   }
 
   public void testInternationalPreferenceOn() throws IOException, TwilioRestException {
     SmsSender smsSender = new SmsSender(twilioSender, Optional.of(nexmoSender), true);
 
-    smsSender.deliverSmsVerification("+441112223333", null, "123-456");
-    verify(twilioSender).deliverSmsVerification("+441112223333", null, "123-456");
+    smsSender.deliverSmsVerification("+441112223333", null, new VerificationCode(123456));
+    verify(twilioSender).deliverSmsVerification("+441112223333", null, new VerificationCode(123456));
     verifyNoMoreInteractions(nexmoSender);
   }
 }

--- a/src/test/java/org/whispersystems/textsecuregcm/tests/sms/DeliveryPreferenceTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/sms/DeliveryPreferenceTest.java
@@ -21,16 +21,16 @@ public class DeliveryPreferenceTest extends TestCase {
   public void testInternationalPreferenceOff() throws IOException, TwilioRestException {
     SmsSender smsSender = new SmsSender(twilioSender, Optional.of(nexmoSender), false);
 
-    smsSender.deliverSmsVerification("+441112223333", "123-456");
-    verify(nexmoSender).deliverSmsVerification("+441112223333", "123-456");
+    smsSender.deliverSmsVerification("+441112223333", null, "123-456");
+    verify(nexmoSender).deliverSmsVerification("+441112223333", null, "123-456");
     verifyNoMoreInteractions(twilioSender);
   }
 
   public void testInternationalPreferenceOn() throws IOException, TwilioRestException {
     SmsSender smsSender = new SmsSender(twilioSender, Optional.of(nexmoSender), true);
 
-    smsSender.deliverSmsVerification("+441112223333", "123-456");
-    verify(twilioSender).deliverSmsVerification("+441112223333", "123-456");
+    smsSender.deliverSmsVerification("+441112223333", null, "123-456");
+    verify(twilioSender).deliverSmsVerification("+441112223333", null, "123-456");
     verifyNoMoreInteractions(nexmoSender);
   }
 }

--- a/src/test/java/org/whispersystems/textsecuregcm/tests/sms/TwilioFallbackTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/sms/TwilioFallbackTest.java
@@ -6,6 +6,7 @@ import junit.framework.TestCase;
 import org.whispersystems.textsecuregcm.sms.NexmoSmsSender;
 import org.whispersystems.textsecuregcm.sms.SmsSender;
 import org.whispersystems.textsecuregcm.sms.TwilioSmsSender;
+import org.whispersystems.textsecuregcm.util.VerificationCode;
 
 import java.io.IOException;
 
@@ -19,16 +20,16 @@ public class TwilioFallbackTest extends TestCase {
 
   @Override
   protected void setUp() throws IOException, TwilioRestException {
-    doThrow(new TwilioRestException("foo", 404)).when(twilioSender).deliverSmsVerification(anyString(), anyString(), anyString());
+    doThrow(new TwilioRestException("foo", 404)).when(twilioSender).deliverSmsVerification(anyString(), anyString(), any(VerificationCode.class));
     doThrow(new TwilioRestException("bar", 405)).when(twilioSender).deliverVoxVerification(anyString(), anyString());
   }
 
   public void testNexmoSmsFallback() throws IOException, TwilioRestException {
     SmsSender smsSender = new SmsSender(twilioSender, Optional.of(nexmoSender), true);
-    smsSender.deliverSmsVerification("+442223334444", null, "123-456");
+    smsSender.deliverSmsVerification("+442223334444", null, new VerificationCode(123456));
 
-    verify(nexmoSender).deliverSmsVerification("+442223334444", null, "123-456");
-    verify(twilioSender).deliverSmsVerification("+442223334444", null, "123-456");
+    verify(nexmoSender).deliverSmsVerification("+442223334444", null, new VerificationCode(123456));
+    verify(twilioSender).deliverSmsVerification("+442223334444", null, new VerificationCode(123456));
   }
 
   public void testNexmoVoxFallback() throws IOException, TwilioRestException {

--- a/src/test/java/org/whispersystems/textsecuregcm/tests/sms/TwilioFallbackTest.java
+++ b/src/test/java/org/whispersystems/textsecuregcm/tests/sms/TwilioFallbackTest.java
@@ -19,16 +19,16 @@ public class TwilioFallbackTest extends TestCase {
 
   @Override
   protected void setUp() throws IOException, TwilioRestException {
-    doThrow(new TwilioRestException("foo", 404)).when(twilioSender).deliverSmsVerification(anyString(), anyString());
+    doThrow(new TwilioRestException("foo", 404)).when(twilioSender).deliverSmsVerification(anyString(), anyString(), anyString());
     doThrow(new TwilioRestException("bar", 405)).when(twilioSender).deliverVoxVerification(anyString(), anyString());
   }
 
   public void testNexmoSmsFallback() throws IOException, TwilioRestException {
     SmsSender smsSender = new SmsSender(twilioSender, Optional.of(nexmoSender), true);
-    smsSender.deliverSmsVerification("+442223334444", "123-456");
+    smsSender.deliverSmsVerification("+442223334444", null, "123-456");
 
-    verify(nexmoSender).deliverSmsVerification("+442223334444", "123-456");
-    verify(twilioSender).deliverSmsVerification("+442223334444", "123-456");
+    verify(nexmoSender).deliverSmsVerification("+442223334444", null, "123-456");
+    verify(twilioSender).deliverSmsVerification("+442223334444", null, "123-456");
   }
 
   public void testNexmoVoxFallback() throws IOException, TwilioRestException {


### PR DESCRIPTION
- Changes the voice verification string.
- Keeps the TextSecure SMS String for matching in Signal for Android.
- Changes TextSecure to Signal for iOS, adding tap to verify link.
- Added test for iOS query parameter.