### PR TITLE
SmsSender: switch string from TextSecure to Signal

### DIFF
--- a/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/sms/SmsSender.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public class SmsSender {
 
   static final String SMS_IOS_VERIFICATION_TEXT = "Your Signal verification code: %s\n\nOr tap: sgnl://verify/%s";
-  static final String SMS_VERIFICATION_TEXT     = "Your TextSecure verification code: %s";
+  static final String SMS_VERIFICATION_TEXT     = "Your Signal verification code: %s";
   static final String VOX_VERIFICATION_TEXT     = "Your Signal verification code is: ";
 
   private final Logger logger = LoggerFactory.getLogger(SmsSender.class);


### PR DESCRIPTION
Fixes #45.

Since TextSecure is now Signal, apply the name change to
Android too.