### PR TITLE
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/src/main/java/org/whispersystems/textsecuregcm/entities/MessageProtos.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/entities/MessageProtos.java
@@ -684,8 +684,7 @@ public final class MessageProtos {
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
+      return new Builder(parent);
     }
     /**
      * Protobuf type {@code textsecure.Envelope}
@@ -1491,8 +1490,7 @@ public final class MessageProtos {
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
+      return new Builder(parent);
     }
     /**
      * Protobuf type {@code textsecure.ProvisioningUuid}

--- a/src/main/java/org/whispersystems/textsecuregcm/storage/Accounts.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/storage/Accounts.java
@@ -92,10 +92,9 @@ public abstract class Accounts {
         throws SQLException
     {
       try {
-        Account account = mapper.readValue(resultSet.getString(DATA), Account.class);
+        return mapper.readValue(resultSet.getString(DATA), Account.class);
 //        account.setId(resultSet.getLong(ID));
 
-        return account;
       } catch (IOException e) {
         throw new SQLException(e);
       }

--- a/src/main/java/org/whispersystems/textsecuregcm/storage/PubSubProtos.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/storage/PubSubProtos.java
@@ -402,8 +402,7 @@ public final class PubSubProtos {
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
+      return new Builder(parent);
     }
     /**
      * Protobuf type {@code textsecure.PubSubMessage}

--- a/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
+++ b/src/main/java/org/whispersystems/textsecuregcm/util/Util.java
@@ -30,9 +30,8 @@ public class Util {
     try {
       MessageDigest digest    = MessageDigest.getInstance("SHA1");
       byte[]        result    = digest.digest(number.getBytes());
-      byte[]        truncated = Util.truncate(result, 10);
+      return Util.truncate(result, 10);
 
-      return truncated;
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError(e);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
Please let me know if you have any questions.
George Kankava